### PR TITLE
SMART values with leading 0's, such as '001' show 4294967295 instead

### DIFF
--- a/usr/lib/hacking-bash.sh
+++ b/usr/lib/hacking-bash.sh
@@ -234,7 +234,7 @@ function is_positive_integer
 {
 	(( $# < 1 )) && return 1
 	
-	[[ $1 =~ ^([1-9][0-9]*|0)$ ]] && return 0
+	[[ $1 =~ ^([0-9]+)$ ]] && return 0
 	
 	return 1
 }


### PR DESCRIPTION
When checking for attribute values to make sure they are positive numbers, the is_positive_integer function will return 0 if the attribute is 0 padded, such as "001".

For example:
**snmpd-smartctl-connector: line 153**
    **if is_positive_integer "${VALUES[3]##0}" && is_positive_integer "${VALUES[5]##0}"; then**

is_positive_integer ends up returning 0, which results in -1 (4294967295) being returned for that SNMP value.


Here is the attribute dump for one of my devices that was having this issue.

**cat /tmp/snmp-cache/smartctl/dev_sda_attr**
smartctl 7.0 2018-12-30 r4883 [x86_64-linux-5.4.45-esos.prod] (local build)
Copyright (C) 2002-18, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF READ SMART DATA SECTION ===
SMART Attributes Data Structure revision number: 1
Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_FAILED RAW_VALUE
  5 Reallocated_Sector_Ct   0x0033   100   100   010    Pre-fail  Always       -       0
  9 Power_On_Hours          0x0032   098   098   000    Old_age   Always       -       6922
 12 Power_Cycle_Count       0x0032   099   099   000    Old_age   Always       -       33
177 Wear_Leveling_Count     0x0013   099   099   000    Pre-fail  Always       -       1
179 Used_Rsvd_Blk_Cnt_Tot   0x0013   100   100   010    Pre-fail  Always       -       0
181 Program_Fail_Cnt_Total  0x0032   100   100   010    Old_age   Always       -       0
182 Erase_Fail_Count_Total  0x0032   100   100   010    Old_age   Always       -       0
183 Runtime_Bad_Block       0x0013   100   100   010    Pre-fail  Always       -       0
187 Uncorrectable_Error_Cnt 0x0032   100   100   000    Old_age   Always       -       0
190 Airflow_Temperature_Cel 0x0032   072   066   000    Old_age   Always       -       28
195 ECC_Error_Rate          0x001a   200   200   000    Old_age   Always       -       0
199 CRC_Error_Count         0x003e   100   100   000    Old_age   Always       -       0
235 POR_Recovery_Count      0x0012   099   099   000    Old_age   Always       -       24
241 Total_LBAs_Written      0x0032   099   099   000    Old_age   Always       -       473795416
